### PR TITLE
Add single slash at beginning of xpath fixes #1

### DIFF
--- a/solution/Umbraco7-7-1/App_Plugins/tooorangey.XPathOfLeastResistance/XPathOfLeastResistance.controller.js
+++ b/solution/Umbraco7-7-1/App_Plugins/tooorangey.XPathOfLeastResistance/XPathOfLeastResistance.controller.js
@@ -31,7 +31,7 @@
         contentResource.getByIds(vm.pathInfo.pathIds).then(function (pathContentArray) {
             console.log(pathContentArray);
             //get the documenttype alias for the path
-            vm.pathInfo.xPath = "root/" + $.map(pathContentArray, function (content) { return content.contentTypeAlias }).join('/');
+            vm.pathInfo.xPath = "/root/" + $.map(pathContentArray, function (content) { return content.contentTypeAlias }).join('/');
             vm.overlay.pathInfo = vm.pathInfo;
             vm.status.loading = false;
    });


### PR DESCRIPTION
Add a single slash at start of xpath to avoid confusion with first el…ement in Umbraco xml being called root